### PR TITLE
Numeric key values and string escaping

### DIFF
--- a/Wkhtmltopdf.cfc
+++ b/Wkhtmltopdf.cfc
@@ -123,6 +123,7 @@ component {
   private function _quote(required string val) {
     // escape and quote the value if it is a string and this isn't windows
     if (server.os.name != 'UNIX') {
+      val = replace(val, '"', '\"', 'all');
       if(val CONTAINS " "){
         return '"#val#"';
       }

--- a/Wkhtmltopdf.cfc
+++ b/Wkhtmltopdf.cfc
@@ -110,7 +110,7 @@ component {
         key = '--' & _dasherize(key);
       }
 
-      if (isBoolean(val) && val != false) {
+      if (!isNumeric(val) && isBoolean(val) && val != false) {
         res.add(key);
       } else {
         res.add(key & ' ' & _quote(val));
@@ -123,7 +123,9 @@ component {
   private function _quote(required string val) {
     // escape and quote the value if it is a string and this isn't windows
     if (server.os.name != 'UNIX') {
-      val = reReplace(val, '(["\\$`])', '\\\1', 'all');
+      if(val CONTAINS " "){
+        return '"#val#"';
+      }
     }
     return val;
   }


### PR DESCRIPTION
I was having problems with numeric key values being treated as booleans and string not being properly escaped. These changes hopefully fix these problems without affecting anything else.
